### PR TITLE
Fix for error in Sorted plugin

### DIFF
--- a/external/Sorted/Core.Sorted.lua
+++ b/external/Sorted/Core.Sorted.lua
@@ -112,10 +112,12 @@ function SortedMixin:Init()
     
     local PreSort = function(itemData)
         local item
-        if Sorted.IsPlayingCharacterSelected() then
+        if Sorted.IsPlayingCharacterSelected() and itemData.bag and itemData.slot then
             item = CaerdonItem:CreateFromBagAndSlot(itemData.bag, itemData.slot)
-        else
+        elseif itemData.link then
             item = CaerdonItem:CreateFromItemLink(itemData.link)
+        else
+            itemData.caerdonStatus = nil
         end
 
         if not item:IsItemDataCached() then


### PR DESCRIPTION
Should fix 'external/Sorted/Core.Sorted.lua:116: Usage: Item:CreateFromBagAndSlot(bagID, slotIndex)' error when used with Sorted addon.