### PR TITLE
fix for Core.WorldQuestTracker.lua:104: Usage: HaveQuestData(questID)

### DIFF
--- a/external/WorldQuestTracker/Core.WorldQuestTracker.lua
+++ b/external/WorldQuestTracker/Core.WorldQuestTracker.lua
@@ -100,6 +100,9 @@ function WorldQuestTrackerMixin:OnUpdateWorldWidget(widget, questID, numObjectiv
     if (type (questID) == "boolean" and questID) then
 		questID = widget.questID
     end
+	if (type (questID) == "table") then
+		questID = questID.questID
+	end
 
     local haveQuestData = HaveQuestData (questID)
 	local haveQuestRewardData = HaveQuestRewardData (questID)


### PR DESCRIPTION
Fix for

```
196x ...xternal/WorldQuestTracker/Core.WorldQuestTracker.lua:104: Usage: HaveQuestData(questID
[string "=[C]"]: in function `HaveQuestData'
[string "@CaerdonWardrobe/external/WorldQuestTracker/Core.WorldQuestTracker.lua"]:104: in function `OnUpdateWorldWidget'
[string "@CaerdonWardrobe/external/WorldQuestTracker/Core.WorldQuestTracker.lua"]:13: in function <...xternal/WorldQuestTracker/Core.WorldQuestTracker.lua:13>
[string "=[C]"]: in function `UpdateWorldWidget'
[string "@WorldQuestTracker/WorldQuestTracker_ZoneMap.lua"]:1885: in function `SetupZoneSummaryButton'
[string "@WorldQuestTracker/WorldQuestTracker_ZoneMap.lua"]:2076: in function `UpdateZoneSummaryFrame'
[string "@WorldQuestTracker/WorldQuestTracker_ZoneMap.lua"]:1238: in function `UpdateZoneWidgets'
[string "@WorldQuestTracker/WorldQuestTracker_MapChange.lua"]:98: in function <...ns/WorldQuestTracker/WorldQuestTracker_MapChange.lua:35>
```